### PR TITLE
Update updatedAt when changing estado

### DIFF
--- a/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/repository/CarreraRepositoryImpl.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/repository/CarreraRepositoryImpl.java
@@ -64,6 +64,7 @@ public class CarreraRepositoryImpl implements CarreraRepository {
         .flatMap(c -> {
           if (c == null) return Mono.empty();
           c.setEstado(nuevoEstado);
+          c.setUpdatedAt(Instant.now());
           return update(c).then();
         });
   }

--- a/src/main/java/pe/edu/perumar/perumar_backend/academico/materias/repository/MateriaRepositoryImpl.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/academico/materias/repository/MateriaRepositoryImpl.java
@@ -63,6 +63,7 @@ public class MateriaRepositoryImpl implements MateriaRepository {
         .flatMap(m -> {
           if (m == null) return Mono.empty();
           m.setEstado(nuevoEstado);
+          m.setUpdatedAt(Instant.now());
           return update(m).then();
         });
   }

--- a/src/test/java/pe/edu/perumar/perumar_backend/academico/carreras/CarreraServiceTest.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/academico/carreras/CarreraServiceTest.java
@@ -184,4 +184,19 @@ class CarreraServiceTest {
 
     verify(carreraRepo).updateEstado("CAR001", "INACTIVO");
   }
+
+  @Test
+  void cambiarEstado_error_propagado() {
+    when(carreraRepo.updateEstado(eq("CAR001"), eq("INACTIVO")))
+        .thenReturn(Mono.error(new RuntimeException("db error")));
+
+    CarreraEstadoRequest er = new CarreraEstadoRequest();
+    er.setEstado("INACTIVO");
+
+    StepVerifier.create(service.cambiarEstado("CAR001", er))
+        .expectErrorMessage("db error")
+        .verify();
+
+    verify(carreraRepo).updateEstado("CAR001", "INACTIVO");
+  }
 }

--- a/src/test/java/pe/edu/perumar/perumar_backend/academico/materias/MateriaServiceTest.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/academico/materias/MateriaServiceTest.java
@@ -117,4 +117,18 @@ class MateriaServiceTest {
 
     verify(repo).updateEstado("MAT001", "INACTIVO");
   }
+
+  @Test
+  void cambiarEstado_error_propagado() {
+    when(repo.updateEstado(eq("MAT001"), eq("INACTIVO")))
+        .thenReturn(Mono.error(new RuntimeException("db error")));
+    MateriaEstadoRequest er = new MateriaEstadoRequest();
+    er.setEstado("INACTIVO");
+
+    StepVerifier.create(service.cambiarEstado("MAT001", er))
+        .expectErrorMessage("db error")
+        .verify();
+
+    verify(repo).updateEstado("MAT001", "INACTIVO");
+  }
 }


### PR DESCRIPTION
## Summary
- ensure updatedAt is refreshed when updating estado for Materia and Carrera
- add service tests checking that updateEstado errors propagate

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cf4af3ec8324ab34a29f2377c51d