### PR TITLE
Handle empty results in reactive repositories

### DIFF
--- a/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/repository/CarreraRepositoryImpl.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/repository/CarreraRepositoryImpl.java
@@ -34,8 +34,9 @@ public class CarreraRepositoryImpl implements CarreraRepository {
   @Override
   public Mono<Carrera> findByCodigo(String codigo) {
     return Mono.fromFuture(
-        table.getItem(r -> r.key(Key.builder().partitionValue(codigo).build()))
-    );
+            table.getItem(r -> r.key(Key.builder().partitionValue(codigo).build()))
+        )
+        .flatMap(Mono::justOrEmpty);
   }
 
   @Override
@@ -50,7 +51,7 @@ public class CarreraRepositoryImpl implements CarreraRepository {
 
   @Override
   public Mono<Boolean> existsByCodigo(String codigo) {
-    return findByCodigo(codigo).map(Objects::nonNull);
+    return findByCodigo(codigo).hasElement();
   }
 
   @Override
@@ -62,7 +63,6 @@ public class CarreraRepositoryImpl implements CarreraRepository {
   public Mono<Void> updateEstado(String codigo, String nuevoEstado) {
     return findByCodigo(codigo)
         .flatMap(c -> {
-          if (c == null) return Mono.empty();
           c.setEstado(nuevoEstado);
           return update(c).then();
         });

--- a/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/service/CarreraService.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/service/CarreraService.java
@@ -62,7 +62,8 @@ public class CarreraService {
   }
 
   public Mono<Carrera> obtener(String codigo) {
-    return repo.findByCodigo(codigo);
+    return repo.findByCodigo(codigo)
+               .switchIfEmpty(Mono.empty());
   }
 
   public Flux<CarreraResponse> listar(String estado) {
@@ -100,11 +101,13 @@ public class CarreraService {
             actual.setUpdatedAt(Instant.now());
             return repo.update(actual);
           }));
-        });
+        })
+        .switchIfEmpty(Mono.empty());
     }
 
   public Mono<Void> cambiarEstado(String codigo, CarreraEstadoRequest req) {
-    return repo.updateEstado(codigo, req.getEstado());
+    return repo.updateEstado(codigo, req.getEstado())
+               .switchIfEmpty(Mono.empty());
   }
 
   public static class DuplicateKeyException extends RuntimeException {
@@ -112,7 +115,8 @@ public class CarreraService {
   }
 
   public Mono<Void> eliminar(String codigo) {
-    return repo.deleteByCodigo(codigo);
+    return repo.deleteByCodigo(codigo)
+               .switchIfEmpty(Mono.empty());
   }
 
 }

--- a/src/main/java/pe/edu/perumar/perumar_backend/academico/materias/repository/MateriaRepositoryImpl.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/academico/materias/repository/MateriaRepositoryImpl.java
@@ -34,7 +34,10 @@ public class MateriaRepositoryImpl implements MateriaRepository {
 
   @Override
   public Mono<Materia> findByCodigo(String codigo) {
-    return Mono.fromFuture(table.getItem(r -> r.key(Key.builder().partitionValue(codigo).build())));
+    return Mono.fromFuture(
+            table.getItem(r -> r.key(Key.builder().partitionValue(codigo).build()))
+        )
+        .flatMap(Mono::justOrEmpty);
   }
 
   @Override
@@ -49,7 +52,7 @@ public class MateriaRepositoryImpl implements MateriaRepository {
 
   @Override
   public Mono<Boolean> existsByCodigo(String codigo) {
-    return findByCodigo(codigo).map(Objects::nonNull);
+    return findByCodigo(codigo).hasElement();
   }
 
   @Override
@@ -61,7 +64,6 @@ public class MateriaRepositoryImpl implements MateriaRepository {
   public Mono<Void> updateEstado(String codigo, String nuevoEstado) {
     return findByCodigo(codigo)
         .flatMap(m -> {
-          if (m == null) return Mono.empty();
           m.setEstado(nuevoEstado);
           return update(m).then();
         });

--- a/src/main/java/pe/edu/perumar/perumar_backend/academico/materias/service/MateriaService.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/academico/materias/service/MateriaService.java
@@ -49,7 +49,8 @@ public class MateriaService {
   }
 
   public Mono<Materia> obtener(String codigo) {
-    return repo.findByCodigo(codigo);
+    return repo.findByCodigo(codigo)
+               .switchIfEmpty(Mono.empty());
   }
 
 public Flux<MateriaResponse> listar(String estado) {
@@ -70,12 +71,14 @@ public Flux<MateriaResponse> listar(String estado) {
           }
           actual.setUpdatedAt(Instant.now());
           return repo.update(actual);
-        });
+        })
+        .switchIfEmpty(Mono.empty());
   }
 
   public Mono<Void> cambiarEstado(String codigo, MateriaEstadoRequest req) {
     // PATCH solo cambia estado
-    return repo.updateEstado(codigo, req.getEstado());
+    return repo.updateEstado(codigo, req.getEstado())
+               .switchIfEmpty(Mono.empty());
   }
 
   // Excepción pequeña para 409
@@ -84,7 +87,8 @@ public Flux<MateriaResponse> listar(String estado) {
   }
 
   public Mono<Void> eliminar(String codigo) {
-      return repo.deleteByCodigo(codigo);
+      return repo.deleteByCodigo(codigo)
+                 .switchIfEmpty(Mono.empty());
   }
 
 }


### PR DESCRIPTION
## Summary
- Avoid null emissions by wrapping DynamoDB lookups with `Mono.justOrEmpty`
- Use `hasElement()` for existence checks instead of null mapping
- Propagate missing records as `Mono.empty()` in service layer

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cf437954832481bbe845f9efc884