### PR TITLE
feat: externalize cors allowed origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,11 @@ src/main/java/pe/edu/perumar/
   ```bash
   eb deploy
   ```
-- **Configuración:**  
-  Variables AWS (`DynamoDB`, `S3`, `Cognito`) en `application.properties` o parámetros de entorno en Elastic Beanstalk.  
+- **Configuración:**
+  Variables AWS (`DynamoDB`, `S3`, `Cognito`) en `application.properties` o parámetros de entorno en Elastic Beanstalk.
+
+- **CORS:**
+  Orígenes permitidos configurables mediante la propiedad `cors.allowed-origins` o la variable de entorno `CORS_ALLOWED_ORIGINS` (valores separados por coma). Por defecto se permite `http://localhost:5173` para desarrollo local.
 
 ---
 

--- a/src/main/java/pe/edu/perumar/perumar_backend/config/CorsGlobalConfig.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/config/CorsGlobalConfig.java
@@ -1,19 +1,21 @@
 package pe.edu.perumar.perumar_backend.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.NonNull;
 import org.springframework.web.reactive.config.CorsRegistry;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
-import org.springframework.lang.NonNull;
 
 @Configuration
 public class CorsGlobalConfig implements WebFluxConfigurer {
+
+    @Value("${cors.allowed-origins:http://localhost:5173}")
+    private String[] allowedOrigins;
+
     @Override
     public void addCorsMappings(@NonNull CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedOrigins(
-                "http://localhost:5173",
-                "http://perumar-backend-env.eba-w9v27vmt.us-east-1.elasticbeanstalk.com"
-            )
+            .allowedOrigins(allowedOrigins)
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowedHeaders("Authorization", "Content-Type")
             .allowCredentials(true);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,3 +40,6 @@ perumar.audit.ddb.table=perumar_audit_menu_click
 server.error.include-message=always
 server.error.include-binding-errors=always
 logging.level.org.springframework.web.bind=DEBUG
+
+# CORS
+cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173}


### PR DESCRIPTION
## Summary
- read allowed CORS origins from `cors.allowed-origins` property with default `http://localhost:5173`
- allow overriding CORS origins per environment using `CORS_ALLOWED_ORIGINS`
- document how to configure origins during deployment

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b908c1db048324a681b1fbe98a16cf