### PR TITLE
refactor: centralize ACL checks

### DIFF
--- a/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/controller/CarreraController.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/controller/CarreraController.java
@@ -3,7 +3,6 @@ package pe.edu.perumar.perumar_backend.academico.carreras.controller;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,8 +13,7 @@ import pe.edu.perumar.perumar_backend.academico.carreras.dto.CarreraUpdateReques
 import pe.edu.perumar.perumar_backend.academico.carreras.mapper.CarreraMapper;
 import pe.edu.perumar.perumar_backend.academico.carreras.service.CarreraService;
 import pe.edu.perumar.perumar_backend.academico.carreras.service.CarreraService.DuplicateKeyException;
-import pe.edu.perumar.perumar_backend.acl.AccessControlService;
-import pe.edu.perumar.perumar_backend.config.SecurityUtils;
+import pe.edu.perumar.perumar_backend.acl.AccessGuard;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -25,88 +23,68 @@ import reactor.core.publisher.Mono;
 public class CarreraController {
 
   private final CarreraService service;
-  private final AccessControlService accessControlService;
+  private final AccessGuard accessGuard;
 
-  public CarreraController(CarreraService service, AccessControlService accessControlService) {
+  public CarreraController(CarreraService service, AccessGuard accessGuard) {
     this.service = service;
-    this.accessControlService = accessControlService;
+    this.accessGuard = accessGuard;
   }
 
   @PostMapping
   public Mono<ResponseEntity<CarreraResponse>> crear(@Valid @RequestBody CarreraRequest req) {
-    return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
-            String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/carreras", "create", "BACKEND");
-            return req;
-        })
-        .flatMap(service::crear)
-        .map(CarreraMapper::toResponse)
-        .map(body -> ResponseEntity.status(HttpStatus.CREATED).body(body));
+    return accessGuard.requireMono(
+        "/api/v1/carreras", "create",
+        () -> service.crear(req)
+            .map(CarreraMapper::toResponse)
+            .map(body -> ResponseEntity.status(HttpStatus.CREATED).body(body))
+    );
   }
 
   @GetMapping
   public Flux<CarreraResponse> listar(@RequestParam(value = "estado", required = false) String estado) {
-    return ReactiveSecurityContextHolder.getContext()
-        .flatMapMany(ctx -> {
-            String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/carreras", "read", "BACKEND");
-            return service.listar(estado); // <- Flux<CarreraResponse>
-        });
+    return accessGuard.requireFlux(
+        "/api/v1/carreras", "read",
+        () -> service.listar(estado)
+    );
   }
 
   @GetMapping("/{codigo}")
   public Mono<CarreraResponse> obtener(@PathVariable String codigo) {
-    return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
-            String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/carreras", "read", "BACKEND");
-            return codigo;
-        })
-        .flatMap(service::obtener)
-        .map(CarreraMapper::toResponse);
+    return accessGuard.requireMono(
+        "/api/v1/carreras", "read",
+        () -> service.obtener(codigo).map(CarreraMapper::toResponse)
+    );
   }
 
   @PutMapping("/{codigo}")
   public Mono<ResponseEntity<CarreraResponse>> actualizar(
       @PathVariable String codigo,
       @Valid @RequestBody CarreraUpdateRequest req) {
-    return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
-            String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/carreras", "edit", "BACKEND");
-            return codigo;
-        })
-        .flatMap(id -> service.actualizar(id, req))
-        .map(CarreraMapper::toResponse)
-        .map(ResponseEntity::ok);
+    return accessGuard.requireMono(
+        "/api/v1/carreras", "edit",
+        () -> service.actualizar(codigo, req)
+            .map(CarreraMapper::toResponse)
+            .map(ResponseEntity::ok)
+    );
   }
 
   @PatchMapping("/{codigo}/estado")
   public Mono<ResponseEntity<Void>> cambiarEstado(
       @PathVariable String codigo,
       @Valid @RequestBody CarreraEstadoRequest req) {
-    return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
-            String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/carreras", "edit_estado", "BACKEND");
-            return codigo;
-        })
-        .flatMap(id -> service.cambiarEstado(id, req))
-        .thenReturn(ResponseEntity.noContent().build());
+    return accessGuard.requireMono(
+        "/api/v1/carreras", "edit_estado",
+        () -> service.cambiarEstado(codigo, req).thenReturn(ResponseEntity.noContent().build())
+    );
   }
 
 
   @DeleteMapping("/{codigo}")
   public Mono<ResponseEntity<Void>> eliminar(@PathVariable String codigo) {
-    return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
-            String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/carreras", "delete", "BACKEND");
-            return codigo;
-        })
-        .flatMap(service::eliminar)
-        .thenReturn(ResponseEntity.noContent().build());
+    return accessGuard.requireMono(
+        "/api/v1/carreras", "delete",
+        () -> service.eliminar(codigo).thenReturn(ResponseEntity.noContent().build())
+    );
   }
 
   @ResponseStatus(HttpStatus.CONFLICT)

--- a/src/main/java/pe/edu/perumar/perumar_backend/academico/materias/controller/MateriaController.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/academico/materias/controller/MateriaController.java
@@ -3,7 +3,6 @@ package pe.edu.perumar.perumar_backend.academico.materias.controller;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,8 +13,7 @@ import pe.edu.perumar.perumar_backend.academico.materias.dto.MateriaUpdateReques
 import pe.edu.perumar.perumar_backend.academico.materias.mapper.MateriaMapper;
 import pe.edu.perumar.perumar_backend.academico.materias.service.MateriaService;
 import pe.edu.perumar.perumar_backend.academico.materias.service.MateriaService.DuplicateKeyException;
-import pe.edu.perumar.perumar_backend.acl.AccessControlService;
-import pe.edu.perumar.perumar_backend.config.SecurityUtils;
+import pe.edu.perumar.perumar_backend.acl.AccessGuard;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -25,91 +23,70 @@ import reactor.core.publisher.Mono;
 public class MateriaController {
 
   private final MateriaService service;
-  private final AccessControlService accessControlService;
+  private final AccessGuard accessGuard;
 
-  public MateriaController(MateriaService service, AccessControlService accessControlService) {
+  public MateriaController(MateriaService service, AccessGuard accessGuard) {
     this.service = service;
-    this.accessControlService = accessControlService;
+    this.accessGuard = accessGuard;
   }
 
   @PostMapping
   public Mono<ResponseEntity<MateriaResponse>> crear(@Valid @RequestBody MateriaRequest req) {
-    return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
-            String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/materias", "create", "BACKEND");
-            return req;
-        })
-        .flatMap(service::crear)
-        .map(MateriaMapper::toResponse)
-        .map(body -> ResponseEntity.status(HttpStatus.CREATED).body(body));
+    return accessGuard.requireMono(
+        "/api/v1/materias", "create",
+        () -> service.crear(req)
+            .map(MateriaMapper::toResponse)
+            .map(body -> ResponseEntity.status(HttpStatus.CREATED).body(body))
+    );
   }
 
   @GetMapping
   public Flux<MateriaResponse> listar(
       @RequestParam(value = "estado", required = false) String estado
   ) {
-    return ReactiveSecurityContextHolder.getContext()
-        .flatMapMany(ctx -> {
-          String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-          accessControlService.requireAccess(role, "/api/v1/materias", "read", "BACKEND");
-          // devolvemos DIRECTAMENTE el Flux del servicio
-          return service.listar(estado); // <- Flux<MateriaResponse>
-        });
+    return accessGuard.requireFlux(
+        "/api/v1/materias", "read",
+        () -> service.listar(estado)
+    );
   }
 
   @GetMapping("/{codigo}")
   public Mono<MateriaResponse> obtener(@PathVariable String codigo) {
-    return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
-            String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/materias", "read", "BACKEND");
-            return codigo;
-        })
-        .flatMap(service::obtener)
-        .map(MateriaMapper::toResponse);
+    return accessGuard.requireMono(
+        "/api/v1/materias", "read",
+        () -> service.obtener(codigo).map(MateriaMapper::toResponse)
+    );
   }
 
   @PutMapping("/{codigo}")
   public Mono<ResponseEntity<MateriaResponse>> actualizar(
       @PathVariable String codigo,
       @Valid @RequestBody MateriaUpdateRequest req) {
-    return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
-            String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/materias", "edit", "BACKEND");
-            return codigo;
-        })
-        .flatMap(id -> service.actualizar(id, req))
-        .map(MateriaMapper::toResponse)
-        .map(ResponseEntity::ok);
+    return accessGuard.requireMono(
+        "/api/v1/materias", "edit",
+        () -> service.actualizar(codigo, req)
+            .map(MateriaMapper::toResponse)
+            .map(ResponseEntity::ok)
+    );
   }
 
   @PatchMapping("/{codigo}/estado")
   public Mono<ResponseEntity<Void>> cambiarEstado(
       @PathVariable String codigo,
       @Valid @RequestBody MateriaEstadoRequest req) {
-    return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
-            String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/materias", "edit_estado", "BACKEND");
-            return codigo;
-        })
-        .flatMap(id -> service.cambiarEstado(id, req))
-        .thenReturn(ResponseEntity.noContent().build());
+    return accessGuard.requireMono(
+        "/api/v1/materias", "edit_estado",
+        () -> service.cambiarEstado(codigo, req).thenReturn(ResponseEntity.noContent().build())
+    );
   }
 
 
   @DeleteMapping("/{codigo}")
   public Mono<ResponseEntity<Void>> eliminar(@PathVariable String codigo) {
-    return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
-            String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/materias", "delete", "BACKEND");
-            return codigo;
-        })
-        .flatMap(service::eliminar)
-        .thenReturn(ResponseEntity.noContent().build());
+    return accessGuard.requireMono(
+        "/api/v1/materias", "delete",
+        () -> service.eliminar(codigo).thenReturn(ResponseEntity.noContent().build())
+    );
   }
 
   @ResponseStatus(HttpStatus.CONFLICT)

--- a/src/main/java/pe/edu/perumar/perumar_backend/acl/AccessGuard.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/acl/AccessGuard.java
@@ -1,0 +1,53 @@
+package pe.edu.perumar.perumar_backend.acl;
+
+import java.util.function.Supplier;
+
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import pe.edu.perumar.perumar_backend.config.SecurityUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Utility component to centralize ACL checks while preserving the reactive
+ * security context. It wraps {@link AccessControlService#requireAccess} and
+ * executes a supplier only when access is granted.
+ */
+@Component
+public class AccessGuard {
+
+    private static final String DEFAULT_SCOPE = "BACKEND";
+
+    private final AccessControlService accessControlService;
+
+    public AccessGuard(AccessControlService accessControlService) {
+        this.accessControlService = accessControlService;
+    }
+
+    public <T> Mono<T> requireMono(String resource, String action, Supplier<Mono<T>> next) {
+        return requireMono(resource, action, DEFAULT_SCOPE, next);
+    }
+
+    public <T> Mono<T> requireMono(String resource, String action, String scope, Supplier<Mono<T>> next) {
+        return ReactiveSecurityContextHolder.getContext()
+                .flatMap(ctx -> {
+                    String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
+                    accessControlService.requireAccess(role, resource, action, scope);
+                    return next.get();
+                });
+    }
+
+    public <T> Flux<T> requireFlux(String resource, String action, Supplier<Flux<T>> next) {
+        return requireFlux(resource, action, DEFAULT_SCOPE, next);
+    }
+
+    public <T> Flux<T> requireFlux(String resource, String action, String scope, Supplier<Flux<T>> next) {
+        return ReactiveSecurityContextHolder.getContext()
+                .flatMapMany(ctx -> {
+                    String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
+                    accessControlService.requireAccess(role, resource, action, scope);
+                    return next.get();
+                });
+    }
+}


### PR DESCRIPTION
## Summary
- add `AccessGuard` component to encapsulate reactive ACL checks
- refactor `MateriaController` and `CarreraController` to use `AccessGuard`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b908bf44dc8324a7d5887afca6476b