### PR TITLE
test: add coverage for service validation and state changes

### DIFF
--- a/src/test/java/pe/edu/perumar/perumar_backend/academico/materias/MateriaServiceTest.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/academico/materias/MateriaServiceTest.java
@@ -77,6 +77,19 @@ class MateriaServiceTest {
   }
 
   @Test
+  void crear_codigoVacio_lanzaError() {
+    // código vacío provoca error inmediato sin tocar repo
+    reqCreate.setCodigo(" ");
+
+    StepVerifier.create(service.crear(reqCreate))
+        .expectError(IllegalArgumentException.class)
+        .verify();
+
+    verify(repo, never()).findByCodigo(any());
+    verify(repo, never()).save(any());
+  }
+
+  @Test
   void actualizar_ok_modificaNombreYDescripcion_noCambiaEstado() {
     Materia actual = new Materia();
     actual.setCodigo("MAT001");
@@ -104,6 +117,17 @@ class MateriaServiceTest {
 
     verify(repo).findByCodigo("MAT001");
     verify(repo).update(any(Materia.class));
+  }
+
+  @Test
+  void actualizar_noExiste_retornaVacio() {
+    when(repo.findByCodigo("MAT001")).thenReturn(Mono.empty());
+
+    StepVerifier.create(service.actualizar("MAT001", new MateriaUpdateRequest()))
+        .verifyComplete();
+
+    verify(repo).findByCodigo("MAT001");
+    verify(repo, never()).update(any());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add MateriaService tests for missing code and update not found
- cover CarreraService update with missing materias and nonexistent state change

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b908bcbac48324b72c3849da1ba7bd