### PR TITLE
Refactor ACL service to reactive

### DIFF
--- a/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/controller/CarreraController.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/controller/CarreraController.java
@@ -35,10 +35,10 @@ public class CarreraController {
   @PostMapping
   public Mono<ResponseEntity<CarreraResponse>> crear(@Valid @RequestBody CarreraRequest req) {
     return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
+        .flatMap(ctx -> {
             String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/carreras", "create", "BACKEND");
-            return req;
+            return accessControlService.requireAccess(role, "/api/v1/carreras", "create", "BACKEND")
+                .thenReturn(req);
         })
         .flatMap(service::crear)
         .map(CarreraMapper::toResponse)
@@ -50,18 +50,18 @@ public class CarreraController {
     return ReactiveSecurityContextHolder.getContext()
         .flatMapMany(ctx -> {
             String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/carreras", "read", "BACKEND");
-            return service.listar(estado); // <- Flux<CarreraResponse>
+            return accessControlService.requireAccess(role, "/api/v1/carreras", "read", "BACKEND")
+                .thenMany(service.listar(estado));
         });
   }
 
   @GetMapping("/{codigo}")
   public Mono<CarreraResponse> obtener(@PathVariable String codigo) {
     return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
+        .flatMap(ctx -> {
             String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/carreras", "read", "BACKEND");
-            return codigo;
+            return accessControlService.requireAccess(role, "/api/v1/carreras", "read", "BACKEND")
+                .thenReturn(codigo);
         })
         .flatMap(service::obtener)
         .map(CarreraMapper::toResponse);
@@ -72,10 +72,10 @@ public class CarreraController {
       @PathVariable String codigo,
       @Valid @RequestBody CarreraUpdateRequest req) {
     return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
+        .flatMap(ctx -> {
             String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/carreras", "edit", "BACKEND");
-            return codigo;
+            return accessControlService.requireAccess(role, "/api/v1/carreras", "edit", "BACKEND")
+                .thenReturn(codigo);
         })
         .flatMap(id -> service.actualizar(id, req))
         .map(CarreraMapper::toResponse)
@@ -87,10 +87,10 @@ public class CarreraController {
       @PathVariable String codigo,
       @Valid @RequestBody CarreraEstadoRequest req) {
     return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
+        .flatMap(ctx -> {
             String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/carreras", "edit_estado", "BACKEND");
-            return codigo;
+            return accessControlService.requireAccess(role, "/api/v1/carreras", "edit_estado", "BACKEND")
+                .thenReturn(codigo);
         })
         .flatMap(id -> service.cambiarEstado(id, req))
         .thenReturn(ResponseEntity.noContent().build());
@@ -100,10 +100,10 @@ public class CarreraController {
   @DeleteMapping("/{codigo}")
   public Mono<ResponseEntity<Void>> eliminar(@PathVariable String codigo) {
     return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
+        .flatMap(ctx -> {
             String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/carreras", "delete", "BACKEND");
-            return codigo;
+            return accessControlService.requireAccess(role, "/api/v1/carreras", "delete", "BACKEND")
+                .thenReturn(codigo);
         })
         .flatMap(service::eliminar)
         .thenReturn(ResponseEntity.noContent().build());

--- a/src/main/java/pe/edu/perumar/perumar_backend/academico/materias/controller/MateriaController.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/academico/materias/controller/MateriaController.java
@@ -35,10 +35,10 @@ public class MateriaController {
   @PostMapping
   public Mono<ResponseEntity<MateriaResponse>> crear(@Valid @RequestBody MateriaRequest req) {
     return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
+        .flatMap(ctx -> {
             String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/materias", "create", "BACKEND");
-            return req;
+            return accessControlService.requireAccess(role, "/api/v1/materias", "create", "BACKEND")
+                .thenReturn(req);
         })
         .flatMap(service::crear)
         .map(MateriaMapper::toResponse)
@@ -52,19 +52,18 @@ public class MateriaController {
     return ReactiveSecurityContextHolder.getContext()
         .flatMapMany(ctx -> {
           String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-          accessControlService.requireAccess(role, "/api/v1/materias", "read", "BACKEND");
-          // devolvemos DIRECTAMENTE el Flux del servicio
-          return service.listar(estado); // <- Flux<MateriaResponse>
+          return accessControlService.requireAccess(role, "/api/v1/materias", "read", "BACKEND")
+              .thenMany(service.listar(estado));
         });
   }
 
   @GetMapping("/{codigo}")
   public Mono<MateriaResponse> obtener(@PathVariable String codigo) {
     return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
+        .flatMap(ctx -> {
             String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/materias", "read", "BACKEND");
-            return codigo;
+            return accessControlService.requireAccess(role, "/api/v1/materias", "read", "BACKEND")
+                .thenReturn(codigo);
         })
         .flatMap(service::obtener)
         .map(MateriaMapper::toResponse);
@@ -75,10 +74,10 @@ public class MateriaController {
       @PathVariable String codigo,
       @Valid @RequestBody MateriaUpdateRequest req) {
     return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
+        .flatMap(ctx -> {
             String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/materias", "edit", "BACKEND");
-            return codigo;
+            return accessControlService.requireAccess(role, "/api/v1/materias", "edit", "BACKEND")
+                .thenReturn(codigo);
         })
         .flatMap(id -> service.actualizar(id, req))
         .map(MateriaMapper::toResponse)
@@ -90,10 +89,10 @@ public class MateriaController {
       @PathVariable String codigo,
       @Valid @RequestBody MateriaEstadoRequest req) {
     return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
+        .flatMap(ctx -> {
             String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/materias", "edit_estado", "BACKEND");
-            return codigo;
+            return accessControlService.requireAccess(role, "/api/v1/materias", "edit_estado", "BACKEND")
+                .thenReturn(codigo);
         })
         .flatMap(id -> service.cambiarEstado(id, req))
         .thenReturn(ResponseEntity.noContent().build());
@@ -103,10 +102,10 @@ public class MateriaController {
   @DeleteMapping("/{codigo}")
   public Mono<ResponseEntity<Void>> eliminar(@PathVariable String codigo) {
     return ReactiveSecurityContextHolder.getContext()
-        .map(ctx -> {
+        .flatMap(ctx -> {
             String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-            accessControlService.requireAccess(role, "/api/v1/materias", "delete", "BACKEND");
-            return codigo;
+            return accessControlService.requireAccess(role, "/api/v1/materias", "delete", "BACKEND")
+                .thenReturn(codigo);
         })
         .flatMap(service::eliminar)
         .thenReturn(ResponseEntity.noContent().build());

--- a/src/main/java/pe/edu/perumar/perumar_backend/acl/AccessControlTestController.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/acl/AccessControlTestController.java
@@ -3,6 +3,7 @@ package pe.edu.perumar.perumar_backend.acl;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 
 
 @RestController
@@ -15,13 +16,13 @@ public class AccessControlTestController {
     }
 
     @GetMapping("/acl/secure-test")
-    public String secureTest(
+    public Mono<String> secureTest(
             @RequestParam String role,
             @RequestParam String resource,
             @RequestParam String action,
             @RequestParam String scope
     ) {
-        accessControlService.requireAccess(role, resource, action, scope);
-        return "✅ Acceso permitido";
+        return accessControlService.requireAccess(role, resource, action, scope)
+                .thenReturn("✅ Acceso permitido");
     }
 }

--- a/src/main/java/pe/edu/perumar/perumar_backend/acl/AclDynamoRepository.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/acl/AclDynamoRepository.java
@@ -1,5 +1,7 @@
 package pe.edu.perumar.perumar_backend.acl;
 
+import reactor.core.publisher.Mono;
+
 public interface AclDynamoRepository {
     /**
      * Verifica si un rol tiene acceso a un recurso con acción y ámbito dados.
@@ -7,7 +9,7 @@ public interface AclDynamoRepository {
      * @param resource Recurso (ej. /api/v1/materias, MATERIA_FORM)
      * @param action   Acción (create, edit, list, view, etc.)
      * @param scope    BACKEND o FRONTEND
-     * @return true si tiene permiso, false si no tiene o no existe el registro
+     * @return Mono que emite true si tiene permiso, false si no tiene o no existe el registro
      */
-    boolean hasAccess(String role, String resource, String action, String scope);
+    Mono<Boolean> hasAccess(String role, String resource, String action, String scope);
 }

--- a/src/main/java/pe/edu/perumar/perumar_backend/acl/AclDynamoRepositoryImpl.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/acl/AclDynamoRepositoryImpl.java
@@ -2,6 +2,8 @@ package pe.edu.perumar.perumar_backend.acl;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
@@ -23,27 +25,29 @@ public class AclDynamoRepositoryImpl implements AclDynamoRepository {
     }
 
     @Override
-    public boolean hasAccess(String role, String resource, String action, String scope) {
-        String resourceKey = String.format("%s#%s#%s", resource, action, scope);
+    public Mono<Boolean> hasAccess(String role, String resource, String action, String scope) {
+        return Mono.fromCallable(() -> {
+            String resourceKey = String.format("%s#%s#%s", resource, action, scope);
 
-        Map<String, AttributeValue> key = new HashMap<>();
-        key.put("role", AttributeValue.builder().s(role).build());
-        key.put("resource_action_scope", AttributeValue.builder().s(resourceKey).build());
+            Map<String, AttributeValue> key = new HashMap<>();
+            key.put("role", AttributeValue.builder().s(role).build());
+            key.put("resource_action_scope", AttributeValue.builder().s(resourceKey).build());
 
-        GetItemRequest request = GetItemRequest.builder()
-                .tableName(tableName)
-                .key(key)
-                .attributesToGet("allow")
-                .consistentRead(true)
-                .build();
+            GetItemRequest request = GetItemRequest.builder()
+                    .tableName(tableName)
+                    .key(key)
+                    .attributesToGet("allow")
+                    .consistentRead(true)
+                    .build();
 
-        GetItemResponse response = dynamoDbClient.getItem(request);
+            GetItemResponse response = dynamoDbClient.getItem(request);
 
-        if (!response.hasItem()) {
-            return false;
-        }
+            if (!response.hasItem()) {
+                return false;
+            }
 
-        AttributeValue allowAttr = response.item().get("allow");
-        return allowAttr != null && allowAttr.bool();
+            AttributeValue allowAttr = response.item().get("allow");
+            return allowAttr != null && allowAttr.bool();
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/src/main/java/pe/edu/perumar/perumar_backend/acl/AclTestController.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/acl/AclTestController.java
@@ -3,6 +3,7 @@ package pe.edu.perumar.perumar_backend.acl;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 
 @RestController
 public class AclTestController {
@@ -14,7 +15,7 @@ public class AclTestController {
     }
 
     @GetMapping("/acl/test")
-    public boolean testAcl(
+    public Mono<Boolean> testAcl(
             @RequestParam String role,
             @RequestParam String resource,
             @RequestParam String action,

--- a/src/test/java/pe/edu/perumar/perumar_backend/academico/carreras/CarreraControllerIT.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/academico/carreras/CarreraControllerIT.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
@@ -49,8 +48,8 @@ class CarreraControllerIT extends BaseIT {
   @BeforeEach
   void setup() {
     // Permitir todos los accesos
-    doNothing().when(accessControlService)
-               .requireAccess(anyString(), anyString(), anyString(), anyString());
+    when(accessControlService.requireAccess(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(Mono.empty());
 
     // Mock materias válidas
     Materia m1 = new Materia(); m1.setCodigo("MAT001"); m1.setNombre("Navegación I"); m1.setEstado("ACTIVO");

--- a/src/test/java/pe/edu/perumar/perumar_backend/academico/ciclos/CicloControllerIT.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/academico/ciclos/CicloControllerIT.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -43,8 +42,8 @@ class CicloControllerIT extends BaseIT {
   @BeforeEach
   void setup() {
     // Permitir todos los accesos
-    doNothing().when(accessControlService)
-               .requireAccess(anyString(), anyString(), anyString(), anyString());
+    when(accessControlService.requireAccess(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(Mono.empty());
 
     c1 = new Ciclo();
     c1.setId(UUID.randomUUID().toString());

--- a/src/test/java/pe/edu/perumar/perumar_backend/academico/materias/MateriaControllerIT.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/academico/materias/MateriaControllerIT.java
@@ -2,7 +2,6 @@ package pe.edu.perumar.perumar_backend.academico.materias;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,8 +44,8 @@ class MateriaControllerIT extends BaseIT {
 
   @BeforeEach
   void setup() {
-    doNothing().when(accessControlService)
-               .requireAccess(anyString(), anyString(), anyString(), anyString());
+    when(accessControlService.requireAccess(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(Mono.empty());
 
     m1 = new Materia();
     m1.setCodigo("MAT001");


### PR DESCRIPTION
## Summary
- make ACL Dynamo repository reactive using `Mono` and `Schedulers.boundedElastic`
- expose reactive `checkAccess` and `requireAccess` in `AccessControlService`
- compose ACL checks reactively in controllers and tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b908b91da88324ad2a578463c72a6a