### PR TITLE
Simplify deleteByCodigo to use direct Mono.fromFuture

### DIFF
--- a/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/repository/CarreraRepositoryImpl.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/repository/CarreraRepositoryImpl.java
@@ -71,8 +71,9 @@ public class CarreraRepositoryImpl implements CarreraRepository {
 
   @Override
   public Mono<Void> deleteByCodigo(String codigo) {
-    return Mono.fromFuture(() -> 
-        table.deleteItem(r -> r.key(Key.builder().partitionValue(codigo).build()))
-    ).then();
+    return Mono.fromFuture(
+            table.deleteItem(r -> r.key(Key.builder().partitionValue(codigo).build()))
+        )
+        .then();
   }
 }

--- a/src/main/java/pe/edu/perumar/perumar_backend/academico/materias/repository/MateriaRepositoryImpl.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/academico/materias/repository/MateriaRepositoryImpl.java
@@ -72,9 +72,10 @@ public class MateriaRepositoryImpl implements MateriaRepository {
 
   @Override
   public Mono<Void> deleteByCodigo(String codigo) {
-      return Mono.fromFuture(() -> 
-          table.deleteItem(r -> r.key(Key.builder().partitionValue(codigo).build()))
-      ).then();
+      return Mono.fromFuture(
+              table.deleteItem(r -> r.key(Key.builder().partitionValue(codigo).build()))
+          )
+          .then();
   }
 
 }


### PR DESCRIPTION
## Summary
- remove lambda supplier when building deletion Mono in Carrera and Materia repositories
- restore mvnw permissions

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68b908b5ad208324a93e3f8a1e4d88b0