### PR TITLE
test: remove duplicate CicloRepository

### DIFF
--- a/src/test/java/pe/edu/perumar/perumar_backend/PerumarBackendApplicationTests.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/PerumarBackendApplicationTests.java
@@ -9,11 +9,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import pe.edu.perumar.perumar_backend.academico.carreras.repository.CarreraRepository;
-import pe.edu.perumar.perumar_backend.academico.ciclos.repository.CicloRepository;
 import pe.edu.perumar.perumar_backend.academico.materias.repository.MateriaRepository;
 
 @SpringBootTest
 @ActiveProfiles("test")
+// TestConfig supplies an in-memory CicloRepository implementation.
 @Import({PerumarBackendApplicationTests.RepoStubs.class, TestConfig.class, DynamoTestConfig.class})
 class PerumarBackendApplicationTests {
 
@@ -24,6 +24,5 @@ class PerumarBackendApplicationTests {
   static class RepoStubs {
     @Bean MateriaRepository materiaRepository() { return Mockito.mock(MateriaRepository.class); }
     @Bean CarreraRepository carreraRepository() { return Mockito.mock(CarreraRepository.class); }
-    @Bean CicloRepository   cicloRepository()   { return Mockito.mock(CicloRepository.class);   }
   }
 }


### PR DESCRIPTION
## Summary
- remove redundant CicloRepository bean in PerumarBackendApplicationTests
- note TestConfig provides in-memory CicloRepository implementation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for pe.edu.perumar:perumar-backend:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68b90d7cd72c8324a612c75f20bf10ac