### PR TITLE
refactor: use JUnit assertions in academico tests

### DIFF
--- a/src/test/java/pe/edu/perumar/perumar_backend/academico/carreras/CarreraServiceTest.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/academico/carreras/CarreraServiceTest.java
@@ -3,6 +3,7 @@ package pe.edu.perumar.perumar_backend.academico.carreras;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Instant;
 import java.util.List;
@@ -66,15 +67,15 @@ class CarreraServiceTest {
 
     StepVerifier.create(service.crear(reqCreate))
       .assertNext(c -> {
-        assert "CAR001".equals(c.getCodigo());
-        assert "Patrón Embarcaciones Menores".equals(c.getNombre());
-        assert "Formación básica".equals(c.getDescripcion());
-        assert c.getModalidad() == ModalidadCarrera.SIN_EXPERIENCIA;
-        assert c.getMaterias().equals(List.of("MAT001","MAT002"));
-        assert "ACTIVO".equals(c.getEstado());
-        assert c.getCreatedAt() != null;
-        assert c.getUpdatedAt() != null;
-        assert !c.getCreatedAt().isAfter(Instant.now());
+        assertEquals("CAR001", c.getCodigo());
+        assertEquals("Patrón Embarcaciones Menores", c.getNombre());
+        assertEquals("Formación básica", c.getDescripcion());
+        assertEquals(ModalidadCarrera.SIN_EXPERIENCIA, c.getModalidad());
+        assertEquals(List.of("MAT001","MAT002"), c.getMaterias());
+        assertEquals("ACTIVO", c.getEstado());
+        assertNotNull(c.getCreatedAt());
+        assertNotNull(c.getUpdatedAt());
+        assertFalse(c.getCreatedAt().isAfter(Instant.now()));
       })
       .verifyComplete();
 
@@ -157,12 +158,12 @@ class CarreraServiceTest {
 
     StepVerifier.create(service.actualizar("CAR001", upd))
       .assertNext(c -> {
-        assert "Nuevo nombre".equals(c.getNombre());
-        assert "Nueva desc".equals(c.getDescripcion());
-        assert c.getModalidad() == ModalidadCarrera.CON_EXPERIENCIA;
-        assert c.getMaterias().equals(List.of("MAT001","MAT002"));
-        assert "ACTIVO".equals(c.getEstado());
-        assert c.getUpdatedAt().isAfter(originalUpdatedAt); // ✅ ahora sí
+        assertEquals("Nuevo nombre", c.getNombre());
+        assertEquals("Nueva desc", c.getDescripcion());
+        assertEquals(ModalidadCarrera.CON_EXPERIENCIA, c.getModalidad());
+        assertEquals(List.of("MAT001","MAT002"), c.getMaterias());
+        assertEquals("ACTIVO", c.getEstado());
+        assertTrue(c.getUpdatedAt().isAfter(originalUpdatedAt)); // ✅ ahora sí
       })
       .verifyComplete();
 

--- a/src/test/java/pe/edu/perumar/perumar_backend/academico/materias/MateriaServiceTest.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/academico/materias/MateriaServiceTest.java
@@ -3,6 +3,7 @@ package pe.edu.perumar.perumar_backend.academico.materias;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Instant;
 
@@ -49,14 +50,14 @@ class MateriaServiceTest {
     StepVerifier.create(service.crear(reqCreate))
       .assertNext(m -> {
         // valores esperados
-        assert "MAT001".equals(m.getCodigo());
-        assert "Matemáticas I".equals(m.getNombre());
-        assert "Base".equals(m.getDescripcion());
-        assert "ACTIVO".equals(m.getEstado());
-        assert m.getCreatedAt() != null;
-        assert m.getUpdatedAt() != null;
+        assertEquals("MAT001", m.getCodigo());
+        assertEquals("Matemáticas I", m.getNombre());
+        assertEquals("Base", m.getDescripcion());
+        assertEquals("ACTIVO", m.getEstado());
+        assertNotNull(m.getCreatedAt());
+        assertNotNull(m.getUpdatedAt());
         // createdAt y updatedAt muy cercanos
-        assert !m.getCreatedAt().isAfter(Instant.now());
+        assertFalse(m.getCreatedAt().isAfter(Instant.now()));
       })
       .verifyComplete();
 
@@ -108,10 +109,10 @@ class MateriaServiceTest {
 
     StepVerifier.create(service.actualizar("MAT001", upd))
       .assertNext(m -> {
-        assert "Nuevo nombre".equals(m.getNombre());
-        assert "Nueva desc".equals(m.getDescripcion());
-        assert "ACTIVO".equals(m.getEstado()); // no cambia aquí
-        assert m.getUpdatedAt().isAfter(Instant.parse("2025-01-01T00:00:00Z"));
+        assertEquals("Nuevo nombre", m.getNombre());
+        assertEquals("Nueva desc", m.getDescripcion());
+        assertEquals("ACTIVO", m.getEstado()); // no cambia aquí
+        assertTrue(m.getUpdatedAt().isAfter(Instant.parse("2025-01-01T00:00:00Z")));
       })
       .verifyComplete();
 


### PR DESCRIPTION
## Summary
- replace Java assert statements with JUnit Assertions in academico service tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b90d8fb5d0832499f466826f3b3980