### PR TITLE
test: add DynamoDB test configuration

### DIFF
--- a/src/test/java/pe/edu/perumar/perumar_backend/BaseIT.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/BaseIT.java
@@ -5,6 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import pe.edu.perumar.perumar_backend.DynamoTestConfig;
 import pe.edu.perumar.perumar_backend.config.TestConfig;
 import pe.edu.perumar.perumar_backend.config.TestSecurityConfig;
 
@@ -13,6 +14,7 @@ import pe.edu.perumar.perumar_backend.config.TestSecurityConfig;
 @ActiveProfiles("test")
 @Import({
   TestConfig.class,         // mocks de repos + stubs AWS
-  TestSecurityConfig.class  // seguridad permitAll en test
+  TestSecurityConfig.class, // seguridad permitAll en test
+  DynamoTestConfig.class    // clientes DynamoDB simulados
 })
 public abstract class BaseIT { }

--- a/src/test/java/pe/edu/perumar/perumar_backend/DynamoTestConfig.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/DynamoTestConfig.java
@@ -1,0 +1,29 @@
+package pe.edu.perumar.perumar_backend;
+
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+
+@TestConfiguration
+@Profile("test")
+public class DynamoTestConfig {
+
+  @Bean
+  @Primary
+  DynamoDbAsyncClient dynamoDbAsyncClient() {
+    return Mockito.mock(DynamoDbAsyncClient.class);
+  }
+
+  @Bean
+  @Primary
+  DynamoDbEnhancedAsyncClient dynamoDbEnhancedAsyncClient(DynamoDbAsyncClient dynamoDbAsyncClient) {
+    return DynamoDbEnhancedAsyncClient.builder()
+        .dynamoDbClient(dynamoDbAsyncClient)
+        .build();
+  }
+}

--- a/src/test/java/pe/edu/perumar/perumar_backend/PerumarBackendApplicationTests.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/PerumarBackendApplicationTests.java
@@ -5,11 +5,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import pe.edu.perumar.perumar_backend.DynamoTestConfig;
 import pe.edu.perumar.perumar_backend.config.TestConfig;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Import(TestConfig.class)
+@Import({TestConfig.class, DynamoTestConfig.class})
 class PerumarBackendApplicationTests {
 
   @Test

--- a/src/test/java/pe/edu/perumar/perumar_backend/config/TestConfig.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/config/TestConfig.java
@@ -13,8 +13,6 @@ import pe.edu.perumar.perumar_backend.academico.materias.repository.MateriaRepos
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Flux;
 
-import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
@@ -36,14 +34,6 @@ public class TestConfig {
   CicloRepository cicloRepository() { return Mockito.mock(CicloRepository.class); }
 
   // ---- Stubs AWS mínimos ----
-  @Bean @Primary
-  DynamoDbAsyncClient dynamoDbAsyncClient() { return Mockito.mock(DynamoDbAsyncClient.class); }
-
-  @Bean @Primary
-  DynamoDbEnhancedAsyncClient dynamoDbEnhancedAsyncClient(DynamoDbAsyncClient c) {
-    return DynamoDbEnhancedAsyncClient.builder().dynamoDbClient(c).build();
-  }
-
   @Bean @Primary
   DynamoDbClient dynamoDbClient() { return Mockito.mock(DynamoDbClient.class); }
 


### PR DESCRIPTION
## Summary
- provide `DynamoTestConfig` with mocked `DynamoDbAsyncClient` and `DynamoDbEnhancedAsyncClient`
- import Dynamo test config in base and application tests
- clean up old dynamo mocks from `TestConfig`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b911bcc30883248e8af34e9dcd0d2b