### PR TITLE
feat: add missing security context check

### DIFF
--- a/src/main/java/pe/edu/perumar/perumar_backend/acl/AccessGuard.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/acl/AccessGuard.java
@@ -31,6 +31,7 @@ public class AccessGuard {
 
     public <T> Mono<T> requireMono(String resource, String action, String scope, Supplier<Mono<T>> next) {
         return ReactiveSecurityContextHolder.getContext()
+                .switchIfEmpty(Mono.error(new AccessDeniedException("Missing SecurityContext")))
                 .flatMap(ctx -> {
                     String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
                     accessControlService.requireAccess(role, resource, action, scope);
@@ -44,6 +45,7 @@ public class AccessGuard {
 
     public <T> Flux<T> requireFlux(String resource, String action, String scope, Supplier<Flux<T>> next) {
         return ReactiveSecurityContextHolder.getContext()
+                .switchIfEmpty(Mono.error(new AccessDeniedException("Missing SecurityContext")))
                 .flatMapMany(ctx -> {
                     String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
                     accessControlService.requireAccess(role, resource, action, scope);


### PR DESCRIPTION
## Summary
- fail fast when ReactiveSecurityContextHolder has no context

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b918833c7483248bc27543c5abf85c