### PR TITLE
Chain access checks through AccessGuard

### DIFF
--- a/src/main/java/pe/edu/perumar/perumar_backend/acl/AccessGuard.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/acl/AccessGuard.java
@@ -33,8 +33,11 @@ public class AccessGuard {
         return ReactiveSecurityContextHolder.getContext()
                 .flatMap(ctx -> {
                     String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-                    accessControlService.requireAccess(role, resource, action, scope);
-                    return next.get();
+                    return accessControlService
+                            .requireAccess(role, resource, action, scope)
+                            .onErrorMap(e -> e instanceof AccessDeniedException ? e
+                                    : new AccessDeniedException(e.getMessage()))
+                            .then(next.get());
                 });
     }
 
@@ -46,8 +49,11 @@ public class AccessGuard {
         return ReactiveSecurityContextHolder.getContext()
                 .flatMapMany(ctx -> {
                     String role = SecurityUtils.extractUserRole(ctx.getAuthentication());
-                    accessControlService.requireAccess(role, resource, action, scope);
-                    return next.get();
+                    return accessControlService
+                            .requireAccess(role, resource, action, scope)
+                            .onErrorMap(e -> e instanceof AccessDeniedException ? e
+                                    : new AccessDeniedException(e.getMessage()))
+                            .thenMany(next.get());
                 });
     }
 }


### PR DESCRIPTION
## Summary
- Ensure access checks are awaited by chaining `requireAccess` with subsequent Mono/Flux operations in `AccessGuard`
- Map any `requireAccess` error to `AccessDeniedException` so unauthorized requests return HTTP 403

## Testing
- `mvn -q -e -ntp test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9188421e48324bd6fc5e1fa100a0b