### PR TITLE
test: stub additional repo methods

### DIFF
--- a/src/test/java/pe/edu/perumar/perumar_backend/config/TestConfig.java
+++ b/src/test/java/pe/edu/perumar/perumar_backend/config/TestConfig.java
@@ -59,17 +59,21 @@ public class TestConfig {
 
       // ===== CARRERAS =====
       when(carreraRepository.findByCodigo(anyString())).thenReturn(Mono.empty());
+      when(carreraRepository.findByEstado(anyString())).thenReturn(Flux.empty());
+      when(carreraRepository.existsByCodigo(anyString())).thenReturn(Mono.just(false));
       when(carreraRepository.save(any()))
           .thenAnswer(inv -> Mono.justOrEmpty(inv.getArgument(0)));
       when(carreraRepository.update(any()))
           .thenAnswer(inv -> Mono.justOrEmpty(inv.getArgument(0)));
-      // Si tu repo define existsByCodigo/updateEstado, puedes habilitarlos:
-      // when(carreraRepository.existsByCodigo(anyString())).thenReturn(Mono.just(false));
-      // doReturn(Mono.empty()).when(carreraRepository).updateEstado(anyString(), anyString());
+      doReturn(Mono.empty()).when(carreraRepository).updateEstado(anyString(), anyString());
+      doReturn(Mono.empty()).when(carreraRepository).deleteByCodigo(anyString());
 
       // ===== CICLOS =====
       when(cicloRepository.findById(anyString())).thenReturn(Mono.empty());
-      // (Si NO hay findAll() en la interfaz, no lo mocks)
+      when(cicloRepository.findByEstado(anyString())).thenReturn(Flux.empty());
+      when(cicloRepository.findByCodigoCarrera(anyString())).thenReturn(Flux.empty());
+      when(cicloRepository.findOverlaps(anyString(), any(), any())).thenReturn(Flux.empty());
+      when(cicloRepository.nextCorrelativo(anyString(), anyInt())).thenReturn(Mono.just(1));
       when(cicloRepository.save(any()))
           .thenAnswer(inv -> Mono.justOrEmpty(inv.getArgument(0)));
       when(cicloRepository.update(any()))


### PR DESCRIPTION
## Summary
- stub carreraRepository methods `findByEstado`, `existsByCodigo`, `updateEstado`, and `deleteByCodigo`
- add `cicloRepository` stubs for listing and overlap queries

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b91f7196e883248478796d81b5e8d9