### PR TITLE
Simplify CarreraService reactive methods

### DIFF
--- a/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/service/CarreraService.java
+++ b/src/main/java/pe/edu/perumar/perumar_backend/academico/carreras/service/CarreraService.java
@@ -62,8 +62,7 @@ public class CarreraService {
   }
 
   public Mono<Carrera> obtener(String codigo) {
-    return repo.findByCodigo(codigo)
-               .switchIfEmpty(Mono.empty());
+    return repo.findByCodigo(codigo);
   }
 
   public Flux<CarreraResponse> listar(String estado) {
@@ -101,13 +100,11 @@ public class CarreraService {
             actual.setUpdatedAt(Instant.now());
             return repo.update(actual);
           }));
-        })
-        .switchIfEmpty(Mono.empty());
+        });
     }
 
   public Mono<Void> cambiarEstado(String codigo, CarreraEstadoRequest req) {
-    return repo.updateEstado(codigo, req.getEstado())
-               .switchIfEmpty(Mono.empty());
+    return repo.updateEstado(codigo, req.getEstado());
   }
 
   public static class DuplicateKeyException extends RuntimeException {
@@ -115,8 +112,7 @@ public class CarreraService {
   }
 
   public Mono<Void> eliminar(String codigo) {
-    return repo.deleteByCodigo(codigo)
-               .switchIfEmpty(Mono.empty());
+    return repo.deleteByCodigo(codigo);
   }
 
 }


### PR DESCRIPTION
## Summary
- Drop redundant `switchIfEmpty(Mono.empty())` calls in `CarreraService`
- Streamline `obtener`, `actualizar`, `cambiarEstado`, and `eliminar`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b91f72271483249eab1fed762b194f